### PR TITLE
Fix for incorrect heat/cold aura values due to unit type flag being additive with abilities

### DIFF
--- a/src/dom5utils/Monster.java
+++ b/src/dom5utils/Monster.java
@@ -292,5 +292,23 @@ public class Monster {
 		}
 		return null;
 	}
-
+	
+	public void setAttributeValue(String key, String value) throws IllegalArgumentException {
+		if (baseAttrs.contains(key)) {
+			try {
+				new PropertyDescriptor(key, Monster.class).getWriteMethod().invoke(this, value);
+				return;
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+					| IntrospectionException e) {
+				e.printStackTrace();
+			}
+		}
+		for (Attr attr : attributes) {
+			if (attr.getKey().equals(key)) {
+				attr.setValue(value);
+				return;
+			}
+		}
+		this.addAttribute(new Attr(key, value));
+	}
 }

--- a/src/dom5utils/MonsterStatIndexer.java
+++ b/src/dom5utils/MonsterStatIndexer.java
@@ -905,7 +905,10 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 				
 				List<String> largeBitmap = largeBitmap(startIndex + 272, values);
 				for (String bit : largeBitmap) {
-					monster.addAttribute(new Attr(bit, 1));
+					// Heat and cold are additive +3 when added this way, and are dealt with below
+					if (bit != "heat" && bit != "cold") {
+						monster.addAttribute(new Attr(bit, 1));
+					}
 				}
 
 				if (monster.getAttribute("slow_to_recruit") != null) {
@@ -915,12 +918,31 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 				}
 				
 				if (largeBitmap.contains("heat")) {
-					monster.addAttribute(new Attr("heat", "3"));
+					String existing = monster.getAttribute("heat");
+					if (existing != null)
+					{
+						Integer newvalue = Integer.parseInt(existing) + 3;
+						monster.setAttributeValue("heat", newvalue.toString());
+					}
+					else
+					{
+						monster.addAttribute(new Attr("heat", "3"));
+					}
 				}
 				
 				if (largeBitmap.contains("cold")) {
-					monster.addAttribute(new Attr("cold", "3"));
+					String existing = monster.getAttribute("cold");
+					if (existing != null)
+					{
+						Integer newvalue = Integer.parseInt(existing) + 3;
+						monster.setAttributeValue("cold", newvalue.toString());
+					}
+					else
+					{
+						monster.addAttribute(new Attr("cold", "3"));
+					}
 				}
+				
 				
 				String additionalLeader = "0";
 				if (monster.getAttribute("additional leadership") != null) {

--- a/src/dom5utils/MonsterStatIndexer.java
+++ b/src/dom5utils/MonsterStatIndexer.java
@@ -79,7 +79,7 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 			"reqtemple", "horrormarked", "changetargetgenderforseductionandseductionimmune", "corpseconstruct", "guardianspiritmodifier", "isashah", "iceforging",
 			"isayazad", "isadaeva", "blessfly", "plant", "clockworklord", "commaster", "comslave", "minsizeleader", "snowmove", "swimming", "stupid",
 			"skirmisher", "ironvul", "heathensummon", "unseen", "illusionary", "reformtime","immortalrespawn", "nomovepen", "wolf", "dungeon", 
-			"graphicsize", "twiceborn", "aboleth", "tmpastralgems", "localsun", "tmpfiregems", "defiler", "mountedbeserk", "lanceok", "startheroab", "minprison", "uwfireshield", "saltvul", "landenc", "plaguedoctor", "curseluckshield", "pathboostuw", "pathboostland", "noarmormapmovepenalty", "farthronekill", "hpoverflow", "indepstay", "polyimmune", "horrormark", "deathdisease", "allret", "percentpathreduction", "aciddigest", "beckon", "slaverbonus", "carcasscollector", "mindcollar", "labpromotion", "mountainrec", "indepspells", "enchrebate50", "summon1", "randomspell", "deathpower", "deathrec", "norange", "insanify", "reanimator", "defector", "nohof", "batstartsum1d3", "enchrebate10", "undying", "moralebonus", "uncurableaffliction", "autoblessed", "wintersummon1d3", "stygianguide", "end"}; 
+			"graphicsize", "twiceborn", "aboleth", "tmpastralgems", "localsun", "tmpfiregems", "defiler", "mountedbeserk", "lanceok", "startheroab", "minprison", "uwfireshield", "saltvul", "landenc", "plaguedoctor", "curseluckshield", "pathboostuw", "pathboostland", "noarmormapmovepenalty", "farthronekill", "hpoverflow", "indepstay", "polyimmune", "horrormark", "deathdisease", "allret", "percentpathreduction", "aciddigest", "beckon", "slaverbonus", "carcasscollector", "mindcollar", "labpromotion", "mountainrec", "indepspells", "enchrebate50", "summon1", "randomspell", "deathpower", "deathrec", "norange", "insanify", "reanimator", "defector", "nohof", "batstartsum1d3", "enchrebate10", "undying", "moralebonus", "uncurableaffliction", "autoblessed", "wintersummon1d3", "stygianguide", "almostundead", "end"}; 
 			
 		
 			
@@ -88,7 +88,7 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 										{"cold", "forestsurvival", "shockres15", "swampsurvival", "demon", "holy", "mountainsurvival", "illusion", "noheal", "ethereal", "pooramphibian", "stealthy40", "misc2", "coldblood", "inanimate", "female" },
 										{"bluntres", "slashres", "pierceres", "slow_to_recruit", "float", "stormimmune", "teleport", "snowmove", "swimming", "domimmortal", "", "", "", "", "", "" },
 										{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" },
-										{"magicbeing", "", "darkvision100", "poormagicleader", "okmagicleader", "goodmagicleader", "expertmagicleader", "superiormagicleader", "poorundeadleader", "okundeadleader", "goodundeadleader", "expertundeadleader", "superiorundeadleader", "", "", "" },
+										{"magicbeing", "", "requndeadleadership", "poormagicleader", "okmagicleader", "goodmagicleader", "expertmagicleader", "superiormagicleader", "poorundeadleader", "okundeadleader", "goodundeadleader", "expertundeadleader", "superiorundeadleader", "", "", "" },
 										{"", "", "", "", "stupid", "", "", "", "noleader", "poorleader", "goodleader", "expertleader", "superiorleader", "", "", "" },
 										{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" },
 										{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" }};
@@ -477,11 +477,11 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 //	0701	Feeblemind chance in province? Kurgi Only [unknown effect]
 //	1A01	? Angels and Celestial Beings only [seems unused]
 //	1B01	? Rudra & Devata only [seems unused]
-//	3F01	? Delgnat Only [used but unknown function]
+//	3F01	? Delgnat Only [changes home province somehow]
 //	6701	? Barbarians & Bakemono-Sho
-//	6801	? Knight & Barbarian commanders [used but unknown function]
+//	6801	? Knight & Barbarian commanders [changes post-script orders, unknown additional variables set]
 //	4501	? Leshy Plainshape only [leads to taking (maxhp*value)/100 damage in certain unknown circumstances]
-//	8401	? Horrors and God Vessels only [used unknown function]
+//	8401	? Horrors and God Vessels only [somehow involved in spellcasting decisions]
 //	8801	Resummon as this shape? Eater of the Dead only [more or less correct, it looks like it will immediately turn the monster into the ID of its magnitude, kinda like firstshape but it has less checks on it]
 //	8A00	? Cockatrice only [may be x% petrification immunity]
 //	9F01	? Soultorn has this at 10 [undying]
@@ -1087,9 +1087,14 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 					}
 					monster.addAttribute(new Attr("stealthy", additionalStealth == null || additionalStealth.equals("0") ? "" : additionalStealth));
 				}
-				if (largeBitmap.contains("darkvision100")) {
-					if (monster.getAttribute("spiritsight") == null) {
-						monster.addAttribute(new Attr("darkvision", 100));
+				if (largeBitmap.contains("requndeadleadership")) {
+					// Formerly "darkvision100", this is the flag that makes a unit require undead leadership
+					// and produces the "Part undead/demon" #almostundead mod command effect
+					// but only if the unit is neither demon nor undead
+					if (monster.getAttribute("undead") == null) {
+						if (monster.getAttribute("demon") == null) {
+							monster.addAttribute(new Attr("almostundead", 1));
+						}
 					}
 				}
 

--- a/src/dom5utils/WeaponStatIndexer.java
+++ b/src/dom5utils/WeaponStatIndexer.java
@@ -109,7 +109,7 @@ public class WeaponStatIndexer extends AbstractStatIndexer {
 					effect.record_number = weaponNumber;
 					effect.object_type = "Weapon";
 					effect.ritual = 0;
-					effect.modifiers_mask = getBytes6(startIndex+64);
+					effect.modifiers_mask = getBytes8(startIndex+64);
 					effect.raw_argument = getBytes2(startIndex+40);
 					effect.range_base = getBytes2(startIndex+56);
 					effect.area_base = getBytes2(startIndex+82);


### PR DESCRIPTION
Three units in the game (Rimvaetti#3406, Abductor#1382, Anointed of Rhuax#1356) had incorrect heat/cold aura values, because the unit data specifies both the aura bitflag AND a unit ID-value pair in the ability slots. The game executable simply adds 3 to the aura value from the slots if the appropriate unit type flag is set, but dom5utils was assigning 3 and discarding the older value.